### PR TITLE
Add fzf for file and word searching in directories

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -35,8 +35,23 @@ Bundle "tpope/vim-rails"
 Bundle "tpope/vim-repeat"
 Bundle "tpope/vim-surround"
 Bundle "vim-scripts/Auto-Pairs"
+Bundle "junegunn/fzf.vim"
+Bundle "/usr/local/opt/fzf"
 
 filetype plugin indent on
+
+" reaching preferences
+let $FZF_DEFAULT_COMMAND = 'ag --hidden --ignore .git -l -g ""'
+nnoremap <C-p> :Files<CR>
+nnoremap <Leader>p :Fi <c-r><c-w><CR>
+vnoremap <leader>p y:Fi <c-r>"<CR>
+
+nnoremap <C-f> :Rg<space>
+nnoremap <leader>f :Rg <c-r><c-w><CR>
+vnoremap <leader>f y:Rg <c-r>"<CR>
+
+command! -bang -nargs=* Fi call fzf#vim#files('.', {'options':'--query '.shellescape(<q-args>)})
+command! -bang -nargs=* Rg call fzf#vim#grep('rg --line-number --hidden --no-heading --color=always --smart-case '.shellescape(<q-args>),1, fzf#vim#with_preview({'options': '--delimiter : --nth 3..'}), <bang>0)
 
 runtime! bundle/snipmate-snippets/support_functions.vim
 runtime macros/matchit.vim


### PR DESCRIPTION
Hi! I'm doing this as part of Hacktoberfest (my first one ever!) https://hacktoberfest.digitalocean.com.

Hey so I've been wondering how I'm going to contribute, and if there is anything I've played around with a lot this year, it would be playing around with dotfiles. 

I saw you recently updated your dotfiles _and_ you use vim. I've been using vim too for a while and I've really loved using `fzf` for quickly reaching different areas of my project very very quickly. Now IMO these are great tools and I've gone really fricken hard on these tools, trying to find the best way forward with them. (https://github.com/suessflorian/Tools/blob/master/init.vim#L37)

I did a PR similar to this just before, albeit, the past one had already an implementation of a fzf using pure `Ag` rather than `Rg`. Here I tried to go full out and propose my approach to reaching instead. 

What I've done here is introduced you to `fzf` https://github.com/junegunn/fzf.vim, `rg` (ripgrep) and `ag` (the silver searcher). They work together to help you do two things, search files in directories and also search words and phrases in directories.

Hope this is interesting. 

Thankyou